### PR TITLE
Changes uitextalignment to nstextalignment

### DIFF
--- a/motion-prime/elements/_text_mixin.rb
+++ b/motion-prime/elements/_text_mixin.rb
@@ -62,7 +62,7 @@ module MotionPrime
           paragrah_style.setLineSpacing(line_spacing)
         end
         if text_alignment
-          text_alignment = text_alignment.uitextalignment if text_alignment.is_a?(Symbol)
+          text_alignment = text_alignment.nstextalignment if text_alignment.is_a?(Symbol)
           paragrah_style.setAlignment(text_alignment)
         end
         if line_break_mode

--- a/motion-prime/elements/draw/label.rb
+++ b/motion-prime/elements/draw/label.rb
@@ -12,7 +12,7 @@ module MotionPrime
       font = (options[:font] || :system).uifont
 
       text_alignment_name = options.fetch(:text_alignment, :left)
-      text_alignment = text_alignment_name.uitextalignment
+      text_alignment = text_alignment_name.nstextalignment
       line_break_mode_name = options.fetch(:line_break_mode, :tail_truncation)
       line_break_mode = line_break_mode_name.uilinebreakmode
 

--- a/motion-prime/support/mp_text_field.rb
+++ b/motion-prime/support/mp_text_field.rb
@@ -32,7 +32,7 @@ class MPTextField < UITextField
 
     truncation = :tail_truncation.uilinebreakmode
     alignment = (placeholderAlignment || :left)
-    alignment = alignment.uitextalignment if alignment.is_a?(Symbol)
+    alignment = alignment.nstextalignment if alignment.is_a?(Symbol)
     self.placeholder.drawInRect(rect, withFont: font, lineBreakMode: truncation, alignment: alignment)
   end
 

--- a/motion-prime/views/view_styler.rb
+++ b/motion-prime/views/view_styler.rb
@@ -151,7 +151,7 @@ module MotionPrime
           view.setValue "UIControlContentHorizontalAlignment#{value.camelize}".constantize, forKey: camelize_factory(key)
           true
         elsif key.end_with?('alignment') && value.is_a?(Symbol)
-          view.setValue value.uitextalignment, forKey: camelize_factory(key)
+          view.setValue value.nstextalignment, forKey: camelize_factory(key)
           true
         elsif key.end_with?('line_break_mode') && value.is_a?(Symbol)
           view.setValue value.uilinebreakmode, forKey: camelize_factory(key)


### PR DESCRIPTION
 Removes deprecated warnings.
**Example:** 2014-04-29 12:25:46.547 Prime Project[76882:70b] uitextalignment is deprecated.  Use nstextalignment instead.
