### PR TITLE
super: no superclass method `apply_padding`

### DIFF
--- a/motion-prime/support/mp_button.rb
+++ b/motion-prime/support/mp_button.rb
@@ -34,7 +34,11 @@ class MPButton < UIButton
   end
 
   def apply_padding?
-    super && !@custom_title_inset_drawn
+    if defined? super
+      super && !@custom_title_inset_drawn
+    else
+      !@custom_title_inset_drawn
+    end
   end
 
   def drawRect(rect)


### PR DESCRIPTION
 mp_button.rb:37:in `apply_padding?': super: no superclass method`apply_padding?' for #MPButton:0x1a625200 (NoMethodError)
    from _padding_attribute.rb:48:in `apply_padding:'
